### PR TITLE
upd substituter - bag vs nobag + upd tests - 28 passing

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -46,6 +46,11 @@ c.meta.substituted = 'metadata.substituted';
 c.meta.base = 'metadata.substitution.base';
 c.meta.overlay = 'metadata.substitution.overlay';
 
+// metadata schema for saving
+c.meta.bag = false;
+c.meta.candidate = false;
+c.meta.compendium = true;
+
 // docker commands
 c.docker = {};
 c.docker.cmd = 'docker run -it --rm';

--- a/lib/model/compendium.js
+++ b/lib/model/compendium.js
@@ -23,7 +23,9 @@ var Compendium = new mongoose.Schema({
   metadata: Object,
   created: {type: Date, default: Date.now},
   jobs: [String],
-  candidate: {type: Boolean, default: true}
+  candidate: {type: Boolean, default: true},
+  bag: {type: Boolean, default: false},
+  compendium: {type: Boolean, default: false}
 });
 Compendium.plugin(timestamps);
 


### PR DESCRIPTION

- substituter will now take the full filepath (basefile, overlayfile), no matter if the base ERC or the overlay ERC is a bag.
- the tests are passing

![update substituter and tests](https://user-images.githubusercontent.com/18659031/32743189-ff3d5880-c8ab-11e7-8ffd-c809ee87f9b4.png)