### PR TITLE
update metadata creation while substitution

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -46,6 +46,16 @@ c.meta.substituted = 'metadata.substituted';
 c.meta.base = 'metadata.substitution.base';
 c.meta.overlay = 'metadata.substitution.overlay';
 
+// for updating path in metadata
+c.meta.updatePath = [
+  'mainfile_candidates', //    xjiYy/data/main.Rmd
+  'mainfile', //   xjiYy/data/main.Rmd
+  'inputfiles', //       xjiYy/data/BerlinMit.csv
+  'ercIdentifier', //      xjiYy
+  'displayfile', //      /api/v1/compendium/xjiYy/data/data/erc.yml
+  'codefiles'  //        xjiYy/data/main.Rmd
+  ]
+
 // metadata schema for saving
 c.meta.bag = false;
 c.meta.candidate = false;

--- a/config/config.js
+++ b/config/config.js
@@ -42,7 +42,7 @@ c.fs.compendium = c.fs.base + 'compendium/';
 
 // metadata extraction and brokering options
 c.meta = {};
-c.meta.substituted = 'metadata.substituted';
+c.meta.substituted = 'substituted';
 c.meta.base = 'metadata.substitution.base';
 c.meta.overlay = 'metadata.substitution.overlay';
 

--- a/controllers/substitute.js
+++ b/controllers/substitute.js
@@ -298,7 +298,7 @@ function updatePathMetadata(passon) {
             passon.baseMetaData = updatedJSON;
             fulfill(passon);
         } catch (err) {
-            debug('[%s] Error updating path in metadata.', passon.id, JSON.stringify(err));
+            debug('[%s] Error updating path in metadata: %s', passon.id, JSON.stringify(err));
             cleanup(passon);
             reject(err);
         }

--- a/controllers/substitute.js
+++ b/controllers/substitute.js
@@ -286,6 +286,7 @@ function updatePathMetadata(passon) {
                 debug('[#%s] update path in metadata at [%s]', i+1, updatedJSON.metadata.o2r[pathsArray[i]]);
                 let stringified = JSON.stringify(updatedJSON.metadata.o2r[pathsArray[i]]);
                 if (passon.bag) { // delete "data/" if base ERC is a bag
+                    debug('[%s] Updating path in metadata - ERC is a bag');
                     if (stringified.indexOf('data/') >= 0) {
                         stringified = stringified.replace('data/', '');
                     }
@@ -298,7 +299,7 @@ function updatePathMetadata(passon) {
             passon.baseMetaData = updatedJSON;
             fulfill(passon);
         } catch (err) {
-            debug('[%s] Error updating path in metadata: %s', passon.id, JSON.stringify(err));
+            debug('[%s] Error updating path in metadata: %s', passon.id, err);
             cleanup(passon);
             reject(err);
         }

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ function initApp(callback) {
           substitution: req.body
         }
       };
+
       debug('[%s] Starting substitution of new compendium [base: "%s" - overlay: "%s"] ...', passon.id, passon.metadata.substitution.base, passon.metadata.substitution.overlay);
       return controllers.substitute.getMetadata(passon)             // get metadata
         .then(controllers.substitute.checkOverlayId)                // check ERC id of overlay ERC

--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ function initApp(callback) {
         .then(controllers.substitute.copyOverlayFiles)              // copy overlay files into folder
         .then(controllers.substitute.createVolumeBinds)             // create metadata for writing to yaml
         .then(controllers.substitute.updateCompendiumConfiguration) // write docker run cmd to erc.yml
+        .then(controllers.substitute.updatePathMetadata)            // update metadata of substituted ERC
         .then(controllers.substitute.saveToDB)                      // save to DB
         .then((passon) => {
           debug('[%s] Finished substitution of new compendium.', passon.id);

--- a/lib/model/compendium.js
+++ b/lib/model/compendium.js
@@ -25,7 +25,8 @@ var Compendium = new mongoose.Schema({
   jobs: [String],
   candidate: {type: Boolean, default: true},
   bag: {type: Boolean, default: false},
-  compendium: {type: Boolean, default: false}
+  compendium: {type: Boolean, default: false},
+  substituted: {type: Boolean, default: false}
 });
 Compendium.plugin(timestamps);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o2r-substituter",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Node.js implementation for compendia substitution [o2r web api](http://o2r.info/o2r-web-api).",
   "main": "index.js",
   "scripts": {

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -61,6 +61,7 @@ describe('List substitutions', function () {
         var overlay_id;
         let base_file = "data/BerlinMit.csv";
         let overlay_file = "data/BerlinOhne.csv";
+        var metadatahandling = "keepBase";
 
         // first upload
         request(req_erc_base02, (err, res, body) => {
@@ -79,7 +80,7 @@ describe('List substitutions', function () {
                         assert.ifError(err);
 
                         // substitution
-                        let req_substitution = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                        let req_substitution = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                         request(req_substitution, (err, res, body) => {
                             assert.ifError(err);
                             substitution_id = body.id;
@@ -122,6 +123,7 @@ describe('List substitutions', function () {
 describe('Simple substitution of data with two ERCs', function () {
     var base_id;
     var overlay_id;
+    var metadatahandling = "keepBase";
 
     before(function (done) {
         let req_erc_base02 = uploadCompendium('./test/erc/base02', cookie_o2r);
@@ -160,7 +162,7 @@ describe('Simple substitution of data with two ERCs', function () {
         it('should respond with HTTP 200 OK and valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -173,7 +175,7 @@ describe('Simple substitution of data with two ERCs', function () {
         it('should respond with valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -184,7 +186,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should respond with valid ID and allow publishing', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -204,9 +206,8 @@ describe('Simple substitution of data with two ERCs', function () {
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                assert.property(response, 'metadata');
-                assert.property(response.metadata, 'substituted');
-                assert.propertyVal(response.metadata, 'substituted', true);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
                 done();
             });
         }).timeout(requestReadingTimeout);
@@ -241,7 +242,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should respond with correct substitution file list with multiple overlays', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 req.json.substitutionFiles.push({ base: "data/Dockerfile", overlay: "data/erc.yml" });
                 req.json.substitutionFiles.push({ base: "data/main.Rmd", overlay: "data/Dockerfile" });
@@ -304,16 +305,16 @@ describe('Simple substitution of data with two ERCs', function () {
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                let rmdfile = path.join(config.fs.compendium, substituted_id, '/data/main.Rmd');
+                let rmdfile = path.join(config.fs.compendium, substituted_id, '/main.Rmd');
                 // let mainhtml = config.fs.compendium + substituted_id + '/data/main.html';
-                let mainhtml = path.join(config.fs.compendium, substituted_id, '/data/main.Rmd');
+                let mainhtml = path.join(config.fs.compendium, substituted_id, '/main.Rmd');
 
                 let doc = fse.readFileSync(mainhtml, 'utf8');
                 let string_ = '"' + 'This is the maximum of ' + "'" + 'Gesamtbilanz' + "'" + ': 1051.2' + '"';
                 assert.include(doc, string_);
                 done();
             });
-        }) //.timeout(requestReadingTimeout); //TODO: till ".skip" Error: cannot read property of undefined
+        }) //.timeout(requestReadingTimeout); //TODO: till "" Error: cannot read property of undefined
     });
 
     describe('POST /api/v1/substitution with an overlay filename that already exists as an base filename', () => {
@@ -323,7 +324,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should respond with HTTP 200 OK', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -336,7 +337,7 @@ describe('Simple substitution of data with two ERCs', function () {
         it('should respond with valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -348,7 +349,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should respond with valid ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -368,9 +369,8 @@ describe('Simple substitution of data with two ERCs', function () {
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                assert.property(response, 'metadata');
-                assert.property(response.metadata, 'substituted');
-                assert.propertyVal(response.metadata, 'substituted', true);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
                 done();
             });
         }).timeout(requestReadingTimeout);
@@ -423,7 +423,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of invalid base ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -441,7 +441,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of missing base ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 delete req.json.base;
 
                 request(req, (err, res, body) => {
@@ -461,7 +461,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of invalid overlay ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -480,7 +480,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of missing overlay ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 delete req.json.overlay;
 
                 request(req, (err, res, body) => {
@@ -499,7 +499,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of invalid base file', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -517,7 +517,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of invalid overlay file', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -535,7 +535,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of empty substitution files', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 req.json.substitutionFiles = [];   // set Array of substitutionFiles empty
 
                 request(req, (err, res, body) => {
@@ -554,7 +554,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of no substitution files', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 delete req.json.substitutionFiles;
 
                 request(req, (err, res, body) => {
@@ -573,7 +573,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of no overlay file in substitution files', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 req.json.substitutionFiles = [{
                     base: "data/BerlinMit.csv"
                 }];
@@ -594,7 +594,7 @@ describe('Simple substitution of data with two ERCs', function () {
 
         it('should fail the substitution because of no base file in substitution files', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
                 req.json.substitutionFiles = [{
                     overlay: "data/BerlinOhne.csv"
                 }];
@@ -615,6 +615,7 @@ describe('Simple substitution of data with two ERCs', function () {
 describe('Simple substitution of data with one ERC (as base) and one WORKSPACE (as overlay)', function () {
     var base_id;
     var overlay_id;
+    var metadatahandling = "keepBase";
 
     before(function (done) {
         let req_erc_base02 = uploadCompendium('./test/erc/base02', cookie_o2r);
@@ -651,7 +652,7 @@ describe('Simple substitution of data with one ERC (as base) and one WORKSPACE (
         it('should respond with HTTP 200 OK and valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -664,7 +665,7 @@ describe('Simple substitution of data with one ERC (as base) and one WORKSPACE (
 
         it('should respond with valid ID (and now publish it)', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -684,9 +685,8 @@ describe('Simple substitution of data with one ERC (as base) and one WORKSPACE (
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                assert.property(response, 'metadata');
-                assert.property(response.metadata, 'substituted');
-                assert.propertyVal(response.metadata, 'substituted', true);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
                 done();
             });
         }).timeout(requestReadingTimeout);
@@ -753,6 +753,7 @@ describe('Simple substitution of data with one ERC (as base) and one WORKSPACE (
 describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (as overlay)', function () {
     var base_id;
     var overlay_id;
+    var metadatahandling = "keepBase";
 
     before(function (done) {
         let req_workspace_base01 = uploadCompendium('./test/workspace/base01', cookie_o2r, 'workspace');
@@ -789,7 +790,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
         it('should respond with HTTP 200 OK and valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -802,7 +803,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
         it('should respond with valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -814,7 +815,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
 
         it('should respond with valid ID', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -834,9 +835,8 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                assert.property(response, 'metadata');
-                assert.property(response.metadata, 'substituted');
-                assert.propertyVal(response.metadata, 'substituted', true);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
                 done();
             });
         }).timeout(requestReadingTimeout);
@@ -903,6 +903,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
 describe('Simple substitution of data with two WORKSPACEs', function () {
     var base_id;
     var overlay_id;
+    var metadatahandling = "keepBase";
 
     before(function (done) {
         let req_workspace_base01 = uploadCompendium('./test/workspace/base01', cookie_o2r, 'workspace');
@@ -940,7 +941,7 @@ describe('Simple substitution of data with two WORKSPACEs', function () {
         it('should respond with HTTP 200 OK and valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -953,7 +954,7 @@ describe('Simple substitution of data with two WORKSPACEs', function () {
 
         it('should respond with valid ID and allow publishing', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -973,9 +974,8 @@ describe('Simple substitution of data with two WORKSPACEs', function () {
             request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
                 assert.ifError(err);
                 let response = JSON.parse(body);
-                assert.property(response, 'metadata');
-                assert.property(response.metadata, 'substituted');
-                assert.propertyVal(response.metadata, 'substituted', true);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
                 done();
             });
         }).timeout(requestReadingTimeout);
@@ -1037,7 +1037,7 @@ describe('Simple substitution of data with two WORKSPACEs', function () {
 
         it('should respond with correct substitution file list with multiple overlays', (done) => {
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 req.json.substitutionFiles.push({ base: "Dockerfile", overlay: "main.Rmd" });
                 req.json.substitutionFiles.push({ base: "main.Rmd", overlay: "Dockerfile" });
@@ -1099,6 +1099,7 @@ describe('Simple substitution of data with two WORKSPACEs', function () {
 describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (as overlay), that should fail', function () {
     var base_id;
     var overlay_id;
+    var metadatahandling = "keepBase";
 
     before(function (done) {
         let req_workspace_base02 = uploadCompendium('./test/workspace/base02', cookie_o2r, 'workspace');
@@ -1135,7 +1136,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
         it('should fail with HTTP 400 and valid JSON', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -1149,7 +1150,7 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
         it('should fail with error configuration is missing', (done) => {
 
             request(global.test_host + '/api/v1/substitution', (err, res, body) => {
-                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie_o2r);
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
 
                 request(req, (err, res, body) => {
                     assert.ifError(err);
@@ -1158,6 +1159,127 @@ describe('Simple substitution of data with one WORKSPACE (as base) and one ERC (
                 });
             });
         }).timeout(requestLoadingTimeout);
+
+    });
+});
+
+// #########################################################################################################################
+
+describe('Substitution with two ERCs checking path updating', function () {
+    var base_id;
+    var overlay_id;
+    var metadatahandling = "keepBase";
+
+    before(function (done) {
+        let req_erc_base02 = uploadCompendium('./test/erc/base02', cookie_o2r);
+        let req_erc_overlay02 = uploadCompendium('./test/erc/overlay02', cookie_o2r);
+        this.timeout(60000);
+
+        // first upload
+        request(req_erc_base02, (err, res, body) => {
+            assert.ifError(err);
+            base_id = JSON.parse(body).id;
+
+            publishCandidate(base_id, cookie_o2r, (err) => {
+                assert.ifError(err);
+
+                // second upload
+                request(req_erc_overlay02, (err, res, body) => {
+                    assert.ifError(err);
+                    overlay_id = JSON.parse(body).id;
+
+                    publishCandidate(overlay_id, cookie_o2r, (err) => {
+                        assert.ifError(err);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    // use two compendia (uploaded before) to run substitution
+    describe('POST /api/v1/substitution with two valid ERCs', () => {
+        var substituted_id;
+        var substituted_id_moreOverlays;
+        let base_file = "data/BerlinMit.csv";
+        let overlay_file = "data/BerlinOhne.csv";
+
+        it('should respond with HTTP 200 OK and valid JSON', (done) => {
+
+            request(global.test_host + '/api/v1/substitution', (err, res, body) => {
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
+
+                request(req, (err, res, body) => {
+                    assert.ifError(err);
+                    assert.equal(res.statusCode, 200);
+                    done();
+                });
+            });
+        }).timeout(requestLoadingTimeout);
+
+        it('should respond with valid JSON', (done) => {
+
+            request(global.test_host + '/api/v1/substitution', (err, res, body) => {
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
+
+                request(req, (err, res, body) => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+        }).timeout(requestLoadingTimeout);
+
+        it('should respond with valid ID and allow publishing', (done) => {
+            request(global.test_host + '/api/v1/substitution', (err, res, body) => {
+                let req = createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie_o2r);
+
+                request(req, (err, res, body) => {
+                    assert.ifError(err);
+                    assert.property(body, 'id');
+                    assert.isString(body.id);
+                    substituted_id = body.id;
+
+                    publishCandidate(substituted_id, cookie_o2r, (err) => {
+                        assert.ifError(err);
+                        done();
+                    });
+                });
+            });
+        }).timeout(requestLoadingTimeout);
+
+        it('should respond with substituted metadata', (done) => {
+            request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
+                assert.ifError(err);
+                let response = JSON.parse(body);
+                assert.property(response, 'substituted');
+                assert.propertyVal(response, 'substituted', true);
+                done();
+            });
+        }).timeout(requestReadingTimeout);
+
+        it('should respond with substituted ERC id in o2r metadata', (done) => {
+            request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
+                assert.ifError(err);
+                let response = JSON.parse(body);
+                assert.property(response, 'metadata');
+                assert.property(response.metadata, 'o2r');
+                assert.property(response.metadata.o2r, 'ercIdentifier');
+                assert.propertyVal(response.metadata.o2r, 'ercIdentifier', substituted_id);
+                done();
+            });
+        }).timeout(requestReadingTimeout);
+
+        it('should respond with updated path in o2r metadata', (done) => {
+            request(global.test_host_read + '/api/v1/compendium/' + substituted_id, (err, res, body) => {
+                assert.ifError(err);
+                let response = JSON.parse(body);
+                assert.property(response, 'metadata');
+                assert.property(response.metadata, 'o2r');
+                assert.property(response.metadata.o2r, 'mainfile');
+                assert.propertyVal(response.metadata.o2r, 'mainfile', 'main.Rmd');
+                done();
+            });
+        }).timeout(requestReadingTimeout);
 
     });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -53,7 +53,7 @@ function uploadCompendium(path, cookie, type = 'compendium') {
     return (reqParams);
 }
 
-function createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, cookie) {
+function createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_file, metadatahandling, cookie) {
 
   let substitutionObject = {
     base: base_id,
@@ -63,7 +63,8 @@ function createSubstitutionPostRequest(base_id, overlay_id, base_file, overlay_f
         base: base_file,
         overlay: overlay_file
       }
-    ]
+    ],
+    metadataHandling: metadatahandling
   }
 
   let j = request.jar();


### PR DESCRIPTION
updatePathMetadata will change manually the path of filepath in the substitution metadata that have been copied from the base ERC metadata